### PR TITLE
Minor pyproject.toml fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
     "umap-learn >= 0.5.3",
     "imbalanced-learn >= 0.10.1",
     "dice-ml >= 0.9",
+    "seaborn",
+    "alibi[ray] >= 0.9.0",
+    "LANDMark@git+https://github.com/jrudar/LANDMark.git", # install from GitHub main branch
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 ]
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.8,<=3.11"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dependencies = [
     "scikit-learn >= 1.1.2",
     "scikit-bio >= 0.5.8",
     "umap-learn >= 0.5.3",
-    "imbalanced-learn >= 0.10.1"
-    "dice-ml >= 0.9"
+    "imbalanced-learn >= 0.10.1",
+    "dice-ml >= 0.9",
 ]
 
 [project.urls]


### PR DESCRIPTION
- `requires-python = ">=3.8,<=3.11"` doesn't allow the package to be installed with Python 3.11.3 for some reason.
- fixed deps list
- added missing deps
- added LANDMark dep install from GitHub